### PR TITLE
Consolidate defined_list/initial_list/frozen_list into entity_list

### DIFF
--- a/openedx_learning/apps/authoring/containers/migrations/0001_initial.py
+++ b/openedx_learning/apps/authoring/containers/migrations/0001_initial.py
@@ -43,9 +43,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('publishable_entity_version', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, primary_key=True, serialize=False, to='oel_publishing.publishableentityversion')),
                 ('container', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='versions', to='oel_containers.containerentity')),
-                ('defined_list', models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, related_name='defined_list', to='oel_containers.entitylist')),
-                ('frozen_list', models.ForeignKey(default=None, null=True, on_delete=django.db.models.deletion.RESTRICT, related_name='frozen_list', to='oel_containers.entitylist')),
-                ('initial_list', models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, related_name='initial_list', to='oel_containers.entitylist')),
+                ('entity_list', models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, related_name='entity_list', to='oel_containers.entitylist')),
             ],
             options={
                 'abstract': False,

--- a/openedx_learning/apps/authoring/containers/models.py
+++ b/openedx_learning/apps/authoring/containers/models.py
@@ -21,7 +21,7 @@ class EntityList(models.Model):
     sometimes we'll want the same kind of data structure for things that we
     dynamically generate for individual students (e.g. Variants). EntityLists are
     anonymous in a sense–they're pointed to by ContainerEntityVersions and
-    other models, rather than being looked up by their own identifers.
+    other models, rather than being looked up by their own identifiers.
     """
 
 
@@ -92,7 +92,7 @@ class ContainerEntityVersion(PublishableEntityVersionMixin):
     The last looks a bit odd, but it's because *how we've defined the Unit* has
     changed if we decide to explicitly pin a set of versions for the children,
     and then later change our minds and move to a different set. It also just
-    makes things easier to reason about if we say that defined_list never
+    makes things easier to reason about if we say that entity_list never
     changes for a given ContainerEntityVersion.
     """
 
@@ -102,46 +102,10 @@ class ContainerEntityVersion(PublishableEntityVersionMixin):
         related_name="versions",
     )
 
-    # This is the EntityList that the author defines. This should never change,
-    # even if the things it references get soft-deleted (because we'll need to
-    # maintain it for reverts).
-    defined_list = models.ForeignKey(
+    # The list of entities (frozen and/or unfrozen) in this container
+    entity_list = models.ForeignKey(
         EntityList,
         on_delete=models.RESTRICT,
         null=False,
-        related_name="defined_list",
-    )
-
-    # inital_list is an EntityList where all the versions are pinned, to show
-    # what the exact versions of the children were at the time that the
-    # Container was created. We could technically derive this, but it would be
-    # awkward to query.
-    #
-    # If the Container was defined so that all references were pinned, then this
-    # can point to the exact same EntityList as defined_list.
-    initial_list = models.ForeignKey(
-        EntityList,
-        on_delete=models.RESTRICT,
-        null=False,
-        related_name="initial_list",
-    )
-
-    # This is the EntityList that's created when the next ContainerEntityVersion
-    # is created. All references in this list should be pinned, and it serves as
-    # "the last state the children were in for this version of the Container".
-    # If defined_list has only pinned references, this should point to the same
-    # EntityList as defined_list and initial_list.
-    #
-    # This value is mutable if and only if there are unpinned references in
-    # defined_list. In that case, frozen_list should start as None, and be
-    # updated to pin references when another version of this Container becomes
-    # the Draft version. But if this version ever becomes the Draft *again*
-    # (e.g. the user hits "discard changes" or some kind of revert happens),
-    # then we need to clear this back to None.
-    frozen_list = models.ForeignKey(
-        EntityList,
-        on_delete=models.RESTRICT,
-        null=True,
-        default=None,
-        related_name="frozen_list",
+        related_name="entity_list",
     )

--- a/openedx_learning/apps/authoring/units/api.py
+++ b/openedx_learning/apps/authoring/units/api.py
@@ -283,7 +283,7 @@ def get_components_in_published_unit_as_of(
     unit_version = unit_pub_entity_version.unitversion  # type: ignore[attr-defined]
 
     entity_list = []
-    rows = unit_version.container_entity_version.defined_list.entitylistrow_set.order_by("order_num")
+    rows = unit_version.container_entity_version.entity_list.entitylistrow_set.order_by("order_num")
     for row in rows:
         if row.entity_version is not None:
             component_version = row.entity_version.componentversion

--- a/tests/openedx_learning/apps/authoring/units/test_api.py
+++ b/tests/openedx_learning/apps/authoring/units/test_api.py
@@ -705,43 +705,7 @@ class UnitTestCase(ComponentTestCase):
         2. The unit version number is 2.
         3. The unit version is in the unit's versions.
         4. The unit version's title is different from the previous version.
-        5. The user defined is the same as the previous version.
-        6. The frozen list is empty.
-        """
-
-    def test_check_author_defined_list_matches_components(self):
-        """Test checking the author defined list matches the components.
-
-        Expected results:
-        1. The author defined list matches the components used to create the unit version.
-        """
-
-    def test_check_initial_list_matches_components(self):
-        """Test checking the initial list matches the components.
-
-        Expected results:
-        1. The initial list matches the components (pinned) used to create the unit version.
-        """
-
-    def test_check_frozen_list_is_none_floating_versions(self):
-        """Test checking the frozen list is None when floating versions are used in the author defined list.
-
-        Expected results:
-        1. The frozen list is None.
-        """
-
-    def test_check_frozen_list_when_next_version_is_created(self):
-        """Test checking the frozen list when a new version is created.
-
-        Expected results:
-        1. The frozen list has pinned versions of the user defined list from the previous version.
-        """
-
-    def test_check_lists_equal_when_pinned_versions(self):
-        """Test checking the lists are equal when pinned versions are used.
-
-        Expected results:
-        1. The author defined list == initial list == frozen list.
+        5. The entity list is the same as the previous version.
         """
 
     def test_publish_unit_version(self):
@@ -768,29 +732,5 @@ class UnitTestCase(ComponentTestCase):
         1. A new unit version is created.
         2. The unit version number is 2.
         3. The unit version is in the unit's versions.
-        4. The user defined list is different from the previous version.
-        5. The initial list contains the pinned versions of the defined list.
-        6. The frozen list is empty.
-        """
-
-    def test_soft_delete_component_from_units(self):
-        """Soft-delete a component from a unit.
-
-        Expected result:
-        After soft-deleting the component (draft), a new unit version (draft) is created for the unit.
-        """
-
-    def test_soft_delete_component_from_units_and_publish(self):
-        """Soft-delete a component from a unit and publish the unit.
-
-        Expected result:
-        After soft-deleting the component (draft), a new unit version (draft) is created for the unit.
-        Then, if the unit is published all units referencing the component are published as well.
-        """
-
-    def test_unit_version_becomes_draft_again(self):
-        """Test a unit version becomes a draft again.
-
-        Expected results:
-        1. The frozen list is None after the unit version becomes a draft again.
+        4. The entity list is different from the previous version.
         """


### PR DESCRIPTION
So far in [all the test cases I've written](https://github.com/open-craft/openedx-learning/blob/braden/containers-units/tests/openedx_learning/apps/authoring/units/test_api.py) including [`test_snapshots_of_published_unit`](https://github.com/open-craft/openedx-learning/blob/e07a741991f42b93cf152857d4e20a16b7e81eec/tests/openedx_learning/apps/authoring/units/test_api.py#L630-L634) (viewing all the historic versions of a unit), there has been no need to reference `initial_list` nor `frozen_list`. So in this PR I'm just removing them entirely, consolidating so that each container only has a single `entity_list`. All of the new "units" tests continue to pass, unchanged.

**Question 1**: Any objections, or am I missing anything? I know we'll need to update the ADRs as well, but they're not included in this branch.

**Question 2**: Do we still need the `EntityList` at all? Right now we have `ContainerEntityVersion` which is 1:1 with `EntityList` and 1:N with `EntityListRow`. It would be simpler to just have `ContainerEntityVersion` which is 1:N with `EntityListRow` directly; no need for an `EntityList` middleman.

The code does say:
> sometimes we'll want the same kind of data structure for things that we
> dynamically generate for individual students (e.g. Variants). EntityLists are
> anonymous in a sense–they're pointed to by ContainerEntityVersions and
> other models, rather than being looked up by their own identifiers.

However, EntityLists as implemented in the prototype are part of the `authoring` suite, so it doesn't seem to me like it would make sense to use them to store anything related to individual students, even if they represent the right kind of data structure for doing so. We could move them out into a `common` app if that is the intention. But perhaps we don't know enough about those use cases yet.

Anyhow, let me know your thoughts!